### PR TITLE
Fix love build (huge zip files)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Get the version
         id: get_version
         run: |
-          if [[ ${{ startsWith(github.ref, 'refs/tags/v') }} ]]; then
+          if ${{ startsWith(github.ref, 'refs/tags/v') }}; then
             echo "TAG_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
             echo "FILE_VERSION=$(cat VERSION)" >> $GITHUB_ENV
           else


### PR DESCRIPTION
Fixes #6 

See PR https://github.com/RafaelWO/love-build/pull/1 for the actual fix. In this repo, the main change is using the forked love-build in the GitHub Action.

Additional changes:
* The version tag is set to `dev` if the workflow is triggered manually
* The version check is skipped if the tag is `dev`