### PR TITLE
✨ Feature: Ship Level Indicator

### DIFF
--- a/src/entity/Entity.lua
+++ b/src/entity/Entity.lua
@@ -78,7 +78,7 @@ function Entity:createHealthbar()
     local barWidth = 100
     local offset = {
         x = self.width / 2 - barWidth / 2,
-        y = -20
+        y = -20 - HEALTH_BAR_TEXT_OFFSET
     }
     self.healthBar = ProgressBar {
         x = self.x + offset.x,
@@ -89,7 +89,10 @@ function Entity:createHealthbar()
         height = 5,
         max = self.health,
         value = self.health,
-        separators = true
+        separators = true,
+        text = string.rep("* ", self.lvl),
+        textAlign = "center",
+        font = gFonts['medium']
     }
 end
 

--- a/src/entity/Player.lua
+++ b/src/entity/Player.lua
@@ -119,8 +119,8 @@ function Player:takeCollisionDamage(damage)
         if self:reduceHealth(damage) then
             gSounds['collision']:stop()
             gSounds['collision']:play()
+            return true
         end
-        return true
     end
     return false
 end

--- a/src/gui/LowHealthOverlay.lua
+++ b/src/gui/LowHealthOverlay.lua
@@ -8,6 +8,7 @@ function LowHealthOverlay:init(def)
     self.alpha = 0
     self.width = def.width or 180
     self.enabled = false
+    self.blinking = false
     self.timer = nil
     self.timers = {}
 end
@@ -27,6 +28,24 @@ function LowHealthOverlay:enable()
     end)
 end
 
+function LowHealthOverlay:blink()
+    if self.enabled then
+        return
+    end
+    self.blinking = true
+    local duration = 0.8
+
+    Timer.tween(duration / 2, {
+        [self] = {alpha = self.maxAlpha}
+    }):group(self.timers)
+    :finish(function()
+        Timer.tween(duration / 2, {
+            [self] = {alpha = 0}
+        }):group(self.timers)
+        self.blinking = false
+    end)
+end
+
 function LowHealthOverlay:disable()
     self.enabled = false
     if self.timer then
@@ -35,13 +54,13 @@ function LowHealthOverlay:disable()
 end
 
 function LowHealthOverlay:update(dt)
-    if self.enabled then
+    if self.enabled or self.blinking then
         Timer.update(dt, self.timers)
     end
 end
 
 function LowHealthOverlay:render()
-    if self.enabled then
+    if self.enabled or self.blinking then
         if self.mode == "full" then
             love.graphics.setColor(self.color.r, self.color.g, self.color.b, self.alpha)
             love.graphics.rectangle('fill', 0, 0 , VIRTUAL_WIDTH, VIRTUAL_HEIGHT)

--- a/src/gui/ProgressBar.lua
+++ b/src/gui/ProgressBar.lua
@@ -26,6 +26,7 @@ function ProgressBar:init(def)
     self.min = def.min or 0
     self.max = def.max
     self.text = def.text
+    self.textAlign = def.textAlign or "left"
     self.font = def.font or gFonts['small']
     self.separators = def.separators or false
     self.cornerRadius = def.cornerRadius or 2
@@ -52,7 +53,7 @@ function ProgressBar:render()
     if self.text then
         love.graphics.setColor(self.textColor.r, self.textColor.g, self.textColor.b, 1)
         love.graphics.setFont(self.font)
-        love.graphics.print(self.text, self.x, self.y)
+        love.graphics.printf(self.text, self.x, self.y, self.width, self.textAlign)
     end
 
     local value = self.value - self.min

--- a/src/world/Level.lua
+++ b/src/world/Level.lua
@@ -29,7 +29,7 @@ function Level:init(params)
     self.lowHealthOverlay = LowHealthOverlay({
         color = {r = 1, g = 0, b = 0},
         interval = 1,
-        maxAlpha = 15/255,
+        maxAlpha = 25/255,
         mode = 'full'
     })
     
@@ -85,6 +85,7 @@ function Level:update(dt)
         if self.player:collides(meteor:getHitbox()) then
             if self.player:takeCollisionDamage(METEOR_COLLISION_DAMAGE) then
                 meteor:reduceHealth(METEOR_COLLISION_DAMAGE)
+                self.lowHealthOverlay:blink()
             end
         end
 
@@ -142,7 +143,9 @@ function Level:update(dt)
         -- Player collision with enemy
         for j, enemyHitbox in pairs(enemy:getHitboxes()) do
             if self.player:collides(enemyHitbox) then
-                self.player:takeCollisionDamage(ENEMY_COLLOSION_DAMAGE)
+                if self.player:takeCollisionDamage(ENEMY_COLLOSION_DAMAGE) then
+                    self.lowHealthOverlay:blink()
+                end
             end
         end
 
@@ -314,6 +317,7 @@ function Level:checkLaserCollision(laser, object)
             if object:reduceHealth(laser.source.attack) and object.type == "player" then
                 gSounds['impact']:stop()
                 gSounds['impact']:play()
+                self.lowHealthOverlay:blink()
             end
         elseif object.meta == "GameObject" and object.type == "meteor" then
             object:reduceHealth(laser.source.attack)


### PR DESCRIPTION
Implements #21 

This PR adds a level indicator above enemy ships. Additionally, the screen blinks red if the player gets a hit.

Each asterisk corresponds to a level, i.e. the green ship below with the 3 asterisks is level 3.

![grafik](https://user-images.githubusercontent.com/38643099/154936001-38ab2379-afa1-48b3-981a-ede32f5a89c3.png)


### Main Changes
✨ Add enemy ship level indicator (asterisk)

#### Other Feature/Fixes
✨ Screen blinks red when player gets hit
