### PR TITLE
✨ Add ship type to highscores

### DIFF
--- a/src/constants.lua
+++ b/src/constants.lua
@@ -41,6 +41,12 @@ HIGHSCORES_LIMIT = 10
 
 FILE_SHIP = "selected_ship"
 
+SHIPNAME_TYPE_MAP = {
+    "classic",
+    "shooter",
+    "sniper"
+}
+
 EXPLOSION_SHORT_COUNT = 17
 EXPLOSION_MEDIUM_COUNT = 13
 

--- a/src/gui/Table.lua
+++ b/src/gui/Table.lua
@@ -5,8 +5,11 @@ function Table:init(def)
     self.y = def.y or (VIRTUAL_HEIGHT / 2)
 
     self.rows = def.rows
+    self.header = def.header
+    self.rowNumbering = def.rowNumbering or true
     self.rowOffset = def.rowOffset or 40
     self.itemOffsets = def.itemOffsets
+    self.lastWrap = def.lastWrap or 100
 end
 
 function Table:update(dt)
@@ -15,15 +18,38 @@ end
 
 function Table:render()
     love.graphics.setFont(gFonts['medium'])
+    if self.header then
+        self:renderHeader()
+    end
     local offsetY = 0
     for i, row in ipairs(self.rows) do
-        love.graphics.printf(i .. ".", self.x, self.y + offsetY, VIRTUAL_WIDTH, 'left')
-        for j, item in ipairs(row) do
-            -- print last item right aligned
-            align = j == #row and "right" or "left"
-            wrap = j == #row and 100 or VIRTUAL_WIDTH
-            love.graphics.printf(item, self.x + self.itemOffsets[j], self.y + offsetY, wrap, align)
-        end
+        self:printRow(row, i, offsetY)
         offsetY = offsetY + self.rowOffset
+    end
+end
+
+function Table:renderHeader()
+    love.graphics.setColor(150/255, 150/255, 150/255, 1)
+    local offsetY = -40
+    self:printRow(self.header, "#", offsetY)
+    love.graphics.setColor(1, 1, 1, 1)
+    love.graphics.line(
+        self.x, self.y - 10,
+        self.x + self.itemOffsets[#self.itemOffsets] + self.lastWrap, self.y - 10
+    )
+end
+
+function Table:printRow(row, rowNumber, offsetY)
+    if offsetY == nil then
+        offsetY = 0
+    end
+    if self.rowNumbering and rowNumber then
+        love.graphics.printf(rowNumber .. ".", self.x, self.y + offsetY, VIRTUAL_WIDTH, 'left')
+    end
+    for j, item in ipairs(row) do
+        -- print last item right aligned
+        align = j == #row and "right" or "left"
+        wrap = j == #row and self.lastWrap or VIRTUAL_WIDTH
+        love.graphics.printf(item, self.x + self.itemOffsets[j], self.y + offsetY, wrap, align)
     end
 end

--- a/src/states/game/GameOverState.lua
+++ b/src/states/game/GameOverState.lua
@@ -6,6 +6,7 @@ function GameOverState:init(params)
     self.name = "GameOverState"
     self.background = Background(MENU_BACKGROUND)
     self.score = params.score
+    self.shipType = params.shipType
     self.playerName = ""
     self.cursor = "_"
     self.cursorTimer = Timer.every(0.5, function()
@@ -83,7 +84,7 @@ function GameOverState:exit()
 end
 
 function GameOverState:submitScore()
-    data = self.playerName .. "," .. self.score .. "\n"
+    data = self.playerName .. "," .. self.shipType .. "," .. self.score .. "\n"
 
     writeSaveFile(FILE_HIGHSCORES, data, 'append')
 end

--- a/src/states/game/HighscoreState.lua
+++ b/src/states/game/HighscoreState.lua
@@ -8,10 +8,11 @@ function HighscoreState:init(params)
     self.scoreRows = self:readScores()
     if self.scoreRows ~= nil then
         self.scoreBoard = Table({
-            x = VIRTUAL_WIDTH / 2 - 150,
+            x = VIRTUAL_WIDTH / 2 - 280,
             y = 330,
             rows = self.scoreRows,
-            itemOffsets = { 50, 200 }
+            header = {"Name", "Ship", "Score"},
+            itemOffsets = { 50, 280, 450 }
         })
     end
 
@@ -64,13 +65,17 @@ function HighscoreState:readScores(limit)
             for item in row:gmatch("([^,]+)") do
                 table.insert(items, item)
             end
+            -- Backwards compatibility: highscores without a ship type will be "n/a"
+            if #items == 2 then
+                table.insert(items, 2, "n/a")
+            end
             table.insert(rows, items)
         end
 
         -- Sort scores descending
         local sortedRows = {}
         local count = 0
-        for k,v in spairs(rows, function(t,a,b) return tonumber(t[a][2]) > tonumber(t[b][2]) end) do
+        for k,v in spairs(rows, function(t,a,b) return tonumber(t[a][3]) > tonumber(t[b][3]) end) do
             table.insert(sortedRows, v)
             count = count + 1
             if count == 10 then
@@ -89,6 +94,13 @@ function HighscoreState:readScores(limit)
         end
 
         writeSaveFile(FILE_HIGHSCORES, data)
+
+        -- Replace ship type (ID) with ship name
+        for i = 1, #sortedRows, 1 do
+            if sortedRows[i][2] ~= "n/a" then
+                sortedRows[i][2] = SHIPNAME_TYPE_MAP[tonumber(sortedRows[i][2])]
+            end
+        end
 
         return sortedRows
     else

--- a/src/world/Level.lua
+++ b/src/world/Level.lua
@@ -342,7 +342,7 @@ end
 function Level:gameOver()
     gSounds['music-lvl' .. self.stage]:stop()
     gStateStack:pop()
-    gStateStack:push(GameOverState({score = self.score}))
+    gStateStack:push(GameOverState({score = self.score, shipType = self.player:getShipType()}))
 end
 
 function Level:changeStage(value)


### PR DESCRIPTION
This PR adds the ship type to the scoreboard, i.e. each high score is associated with a ship.

For scores saved prior to this change, the ship type is `n/a`

### Main Changes
* ✨ Add rendering of a table header in class Table

![grafik](https://user-images.githubusercontent.com/38643099/164033539-15547d86-ff8a-4b6f-87fc-3f282de0d907.png)
